### PR TITLE
hot fix for 206

### DIFF
--- a/lib/command/base.coffee
+++ b/lib/command/base.coffee
@@ -53,7 +53,7 @@ module.exports = class Base
     contextArg[@context] = keymapArg
 
     # Capture the disposable heretom test!
-    @disposables.add atom.keymap.add name, contextArg
+    @disposables.add atom.keymaps.add name, contextArg
 
   splitPair: (pair) ->
     return [pair[..(pair.length/2)-1], pair[pair.length/2..]]


### PR DESCRIPTION
Here is a fix for https://github.com/gepoch/vim-surround/issues/15#issuecomment-109256345 it looks like they rename `atom.keymap` to `atom.keymapS`