### PR TITLE
Implement delete change surround

### DIFF
--- a/lib/command/change.coffee
+++ b/lib/command/change.coffee
@@ -1,0 +1,74 @@
+{CompositeDisposable} = require 'atom'
+
+Base = require './base'
+Selector = require './selector'
+
+module.exports = class Change
+  constructor: (config) ->
+    @command = config.changeSurroundCommand
+    @context = "atom-text-editor.vim-mode.command-mode"
+    @disposables = new CompositeDisposable
+    @curPairs = []
+    @curPairsWithTarget = []
+    @registerPairs config.pairs
+
+  getName: (key, targetKey) -> "change-#{key}-to-#{targetKey}"
+
+  registerPairs: (pairs) ->
+    pairs = (x for x in pairs when x.length > 0 and x.length %2 == 0)
+
+    for pair in pairs
+      for target in pairs
+        if "#{pair}#{target}" not in @curPairs
+          @registerPair pair, target
+          @curPairs.push("#{pair}#{target}")
+
+  registerPair: (pair, target) ->
+    [left, right] = @splitPair(pair)
+    [target_left, target_right] = @splitPair(target)
+
+    for key in [left, right]
+      for targetKey in [target_left, target_right]
+        if "#{key}#{targetKey}" not in @curPairsWithTarget
+          name = "vim-surround:#{@getName(key, targetKey)}"
+
+          unless pair == target
+            @disposables.add atom.commands.add @context, name, @getRunner pair, target
+
+          keymapArg = {}
+          fullCommand = "#{@command} #{key} #{targetKey}"
+          keymapArg[fullCommand] = name
+
+          contextArg = {}
+          contextArg[@context] = keymapArg
+
+          # Capture the disposable heretom test!
+          unless pair == target
+            @disposables.add atom.keymaps.add name, contextArg
+          @curPairsWithTarget.push("#{key}#{targetKey}")
+
+  splitPair: (pair) ->
+    return [pair[..(pair.length/2)-1], pair[pair.length/2..]]
+
+  getRunner: (from, to) -> ->
+    [left, right] = [from[0], from[1]]
+    [target_left, target_right] = [to[0], to[1]]
+    editor = atom.workspace.getActiveTextEditor()
+    selector = new Selector(editor, left, right)
+
+    editor.transact ->
+      cursorPos = editor.getCursorBufferPosition()
+
+      selector.inside().select()
+      editor.selections.forEach (selection) ->
+        text = selection.getText()
+
+        # restore cursore and select text with surrounding keys
+        editor.setCursorBufferPosition(cursorPos)
+        selector.outside().select()
+
+        editor.selections.forEach (selection) ->
+          selection.insertText "#{target_left}#{text}#{target_right}"
+
+      # restore cursore
+      editor.setCursorBufferPosition(cursorPos)

--- a/lib/command/selector.coffee
+++ b/lib/command/selector.coffee
@@ -1,0 +1,22 @@
+vimModePath = atom.packages.resolvePackagePath('vim-mode')
+{SelectInsideQuotes, SelectInsideBrackets} = require "#{vimModePath}/lib/text-objects"
+
+module.exports = class Selector
+  constructor: (@editor, left, right) ->
+    @left = left.trim()
+    @right = right.trim()
+
+  inside: ->
+    if @isBraket()
+      new SelectInsideBrackets(@editor, @left, @right, false)
+    else
+      new SelectInsideQuotes(@editor, @left, false)
+
+  outside: ->
+    if @isBraket()
+      new SelectInsideBrackets(@editor, @left, @right, true)
+    else
+      new SelectInsideQuotes(@editor, @left, true)
+
+  isBraket: ->
+    ['[', ']', '{', '}', '<', '>', '(', ')'].indexOf?(@left.trim()) >= 0

--- a/lib/vim-surround.coffee
+++ b/lib/vim-surround.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable} = require 'atom'
 
 Surround = require './command/surround'
+Delete = require './command/delete'
 
 module.exports =
   config:
@@ -9,13 +10,16 @@ module.exports =
       default: ['()', '{}', '[]', '""', "''"]
       items:
         type: 'string'
+    deleteSurroundCommand:
+      type: 'string'
+      default: 'd'
     surroundCommand:
       type: 'string'
       default: 's'
 
   activate: (state) ->
     @commandClasses = [
-      Surround
+      Surround, Delete
     ]
 
     @configLoop = atom.config.observe 'vim-surround', (config) =>

--- a/lib/vim-surround.coffee
+++ b/lib/vim-surround.coffee
@@ -2,6 +2,7 @@
 
 Surround = require './command/surround'
 Delete = require './command/delete'
+Change = require './command/change'
 
 module.exports =
   config:
@@ -10,16 +11,19 @@ module.exports =
       default: ['()', '{}', '[]', '""', "''"]
       items:
         type: 'string'
+    changeSurroundCommand:
+      type: 'string'
+      default: 'c s'
     deleteSurroundCommand:
       type: 'string'
-      default: 'd'
+      default: 'd s'
     surroundCommand:
       type: 'string'
       default: 's'
 
   activate: (state) ->
     @commandClasses = [
-      Surround, Delete
+      Surround, Delete, Change
     ]
 
     @configLoop = atom.config.observe 'vim-surround', (config) =>

--- a/spec/vim-surround-spec.coffee
+++ b/spec/vim-surround-spec.coffee
@@ -1,6 +1,5 @@
 helpers = require './spec-helper'
 
-
 describe "Vim Surround activation", ->
   [editor, pairs, editorElement, vimSurround, configPairs, chars, names] = []
 


### PR DESCRIPTION
Hi there, I've implemented `Change` and `Delete` surround. Can we discuss it ? I am not sure about performance side of my solution and it defiantly has some corner cases, but it works for me.

I don't have much experience with testing in  `Atom` if you can help me with this it would be grate.

What has been done so far: 

- [x] Change surround by `c s`
- [x] Delete surround by `d s`

### Known issues
`vim-mode` will change paragraph if you press `c s {` without target surround.
   