### PR TITLE
Add backticks to the default list of pairs.

### DIFF
--- a/lib/vim-surround.coffee
+++ b/lib/vim-surround.coffee
@@ -8,7 +8,7 @@ module.exports =
   config:
     pairs:
       type: 'array'
-      default: ['()', '{}', '[]', '""', "''"]
+      default: ['()', '{}', '[]', '""', "''", '``']
       items:
         type: 'string'
     changeSurroundCommand:


### PR DESCRIPTION
I found myself missing this from vim-surround proper. Cheers!
