### PR TITLE
Add backtick support by default.

### DIFF
--- a/lib/vim-surround.coffee
+++ b/lib/vim-surround.coffee
@@ -8,7 +8,7 @@ module.exports =
   config:
     pairs:
       type: 'array'
-      default: ['()', '{}', '[]', '""', "''"]
+      default: ['()', '{}', '[]', '""', "''", "``"]
       items:
         type: 'string'
     changeSurroundCommand:


### PR DESCRIPTION
Backticks are used very frequently in ES6, should be enabled by default.